### PR TITLE
fix: use default options as fallback when nvls_options is nil

### DIFF
--- a/lua/nvls.lua
+++ b/lua/nvls.lua
@@ -119,7 +119,7 @@ function M.syntax()
 end
 
 M.get_nvls_options = function()
-  return nvls_options
+  return nvls_options or default
 end
 
 return M


### PR DESCRIPTION
This partly fixes #24 