### PR TITLE
fix fluidsynth channel count, add ffmpeg_flags config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ If you want to use all the functions (player, hyphenation for various languages.
         midi_synth = "fluidsynth",
         fluidsynth_flags = nil,
         timidity_flags = nil,
+        ffmpeg_flags = nil,
         audio_format = "mp3",
         mpv_flags = {
           "--msg-level=cplayer=no,ffmpeg=no,alsa=no",

--- a/lua/nvls.lua
+++ b/lua/nvls.lua
@@ -114,6 +114,7 @@ local default = {
       midi_synth = "fluidsynth",
       fluidsynth_flags = nil,
       timidity_flags = nil,
+      ffmpeg_flags = nil,
       audio_format = "mp3",
       mpv_flags = {
         "--msg-level=cplayer=no,ffmpeg=no,alsa=no",

--- a/lua/nvls/player.lua
+++ b/lua/nvls/player.lua
@@ -27,10 +27,12 @@ local function create_audio(midi_input, format)
     Utils.insert_flags(fluidsynth_args, nvls_options.player.options.fluidsynth_flags, true)
 
     local ffmpeg_args = {
-      "-f", "s32le",
+      "-ac", "2",
+      "-f", "s16le",
       "-i", raw_file,
-      audio_out
     }
+    Utils.insert_flags(ffmpeg_args, nvls_options.player.options.ffmpeg_flags)
+    Utils.insert_flags(ffmpeg_args, audio_out)
 
     Job:add("fluidsynth", fluidsynth_args)
     Job:add("ffmpeg", ffmpeg_args, nil, function()


### PR DESCRIPTION
this commit fixes an issue where ffmpeg treats two 16-bit channels as one 32-bit channel, effectively leaving only one channel in the final audio output
also adds an ffmpeg_flags config option because why not